### PR TITLE
Add `SnapshotStakingPool` and `SignedSnapshotStakingPool` Audit Remediations

### DIFF
--- a/src/interfaces/staking/ISignedSnapshotStakingPool.sol
+++ b/src/interfaces/staking/ISignedSnapshotStakingPool.sol
@@ -26,6 +26,10 @@ interface ISignedSnapshotStakingPool is ISnapshotStakingPool {
     /// @param signature The signature of the message
     function approveStaker(bytes calldata signature) external;
 
+    /// @notice Set the message to sign when staking
+    /// @param newMessage The new message
+    function setMessage(string calldata newMessage) external;
+
     /// @notice Get the hashed digest of the message to be signed for staking
     /// @return The hashed bytes to be signed
     function getStakeSignatureDigest() external view returns (bytes32);

--- a/src/interfaces/staking/ISignedSnapshotStakingPool.sol
+++ b/src/interfaces/staking/ISignedSnapshotStakingPool.sol
@@ -28,7 +28,7 @@ interface ISignedSnapshotStakingPool is ISnapshotStakingPool {
 
     /// @notice Set the message to sign when staking
     /// @param newMessage The new message
-    function setMessage(string calldata newMessage) external;
+    function setMessage(string memory newMessage) external;
 
     /// @notice Get the hashed digest of the message to be signed for staking
     /// @return The hashed bytes to be signed

--- a/src/interfaces/staking/ISnapshotStakingPool.sol
+++ b/src/interfaces/staking/ISnapshotStakingPool.sol
@@ -52,8 +52,6 @@ interface ISnapshotStakingPool is IERC20 {
     /// @param endSnapshotId The snapshot id to end the partial claim
     function claimPartial(uint256 startSnapshotId, uint256 endSnapshotId) external;
 
-    /* ========== Admin Functions ========== */
-
     /// @notice ONLY OWNER: Update the distributor address.
     /// @param newDistributor The new distributor address
     function setDistributor(address newDistributor) external;
@@ -65,8 +63,6 @@ interface ISnapshotStakingPool is IERC20 {
     /// @notice ONLY OWNER: Update the snapshot delay. Can set to 0 to disable snapshot delay.
     /// @param newSnapshotDelay The new snapshot delay
     function setSnapshotDelay(uint256 newSnapshotDelay) external;
-
-    /* ========== View Functions ========== */
 
     /// @notice Get the current snapshot id.
     /// @return The current snapshot id

--- a/src/interfaces/staking/ISnapshotStakingPool.sol
+++ b/src/interfaces/staking/ISnapshotStakingPool.sol
@@ -14,7 +14,10 @@ interface ISnapshotStakingPool is IERC20 {
     /// @notice Distributor of rewards
     function distributor() external view returns (address);
 
-    /// @notice Snapshot delay
+    /// @notice The buffer time before snapshots during which staking is not allowed
+    function snapshotBuffer() external view returns (uint256);
+
+    /// @notice The minimum amount of time between snapshots
     function snapshotDelay() external view returns (uint256);
 
     /// @notice Last snapshot time
@@ -54,6 +57,10 @@ interface ISnapshotStakingPool is IERC20 {
     /// @notice ONLY OWNER: Update the distributor address.
     /// @param newDistributor The new distributor address
     function setDistributor(address newDistributor) external;
+
+    /// @notice ONLY OWNER: Update the snapshot buffer.
+    /// @param newSnapshotBuffer The new snapshot buffer
+    function setSnapshotBuffer(uint256 newSnapshotBuffer) external;
 
     /// @notice ONLY OWNER: Update the snapshot delay. Can set to 0 to disable snapshot delay.
     /// @param newSnapshotDelay The new snapshot delay
@@ -100,4 +107,20 @@ interface ISnapshotStakingPool is IERC20 {
     /// @notice Get the time until the next snapshot.
     /// @return The time until the next snapshot
     function getTimeUntilNextSnapshot() external view returns (uint256);
+
+    /// @notice Get the next snapshot time.
+    /// @return The next snapshot time
+    function getNextSnapshotTime() external view returns (uint256);
+
+    /// @notice Check if staking is allowed.
+    /// @return Boolean indicating if staking is allowed
+    function canStake() external view returns (bool);
+
+    /// @notice Get the time until the next snapshot buffer begins.
+    /// @return The time until the next snapshot buffer begins
+    function getTimeUntilNextSnapshotBuffer() external view returns (uint256);
+
+    /// @notice Get the next snapshot buffer time.
+    /// @return The next snapshot buffer time
+    function getNextSnapshotBufferTime() external view returns (uint256);
 }

--- a/src/staking/SignedSnapshotStakingPool.sol
+++ b/src/staking/SignedSnapshotStakingPool.sol
@@ -11,7 +11,10 @@ import {SnapshotStakingPool} from "./SnapshotStakingPool.sol";
 /// @title SignedSnapshotStakingPool
 /// @author Index Cooperative
 /// @notice A contract for staking `stakeToken` and receiving `rewardToken` based 
-/// on snapshots taken when rewards are accrued.
+/// on snapshots taken when rewards are accrued. Snapshots are taken at a minimum
+/// interval of `snapshotDelay` seconds. Staking is not allowed `snapshotBuffer` 
+/// seconds before a snapshot is taken. Rewards are distributed by the `distributor`.
+/// Stakers must sign an agreement `message` to stake.
 contract SignedSnapshotStakingPool is ISignedSnapshotStakingPool, SnapshotStakingPool, EIP712 {
     string private constant MESSAGE_TYPE = "StakeMessage(string message)";
 
@@ -69,20 +72,20 @@ contract SignedSnapshotStakingPool is ISignedSnapshotStakingPool, SnapshotStakin
     /* STAKER FUNCTIONS */
 
     /// @inheritdoc ISignedSnapshotStakingPool
-    function stake(uint256 _amount) external override(SnapshotStakingPool, ISignedSnapshotStakingPool) nonReentrant {
+    function stake(uint256 amount) external override(SnapshotStakingPool, ISignedSnapshotStakingPool) nonReentrant {
         if (!isApprovedStaker[msg.sender]) revert NotApprovedStaker();
-        _stake(msg.sender, _amount);
+        _stake(msg.sender, amount);
     }
 
     /// @inheritdoc ISignedSnapshotStakingPool
-    function stake(uint256 _amount, bytes calldata _signature) external nonReentrant {
-        _approveStaker(msg.sender, _signature);
-        _stake(msg.sender, _amount);
+    function stake(uint256 amount, bytes calldata signature) external nonReentrant {
+        _approveStaker(msg.sender, signature);
+        _stake(msg.sender, amount);
     }
 
     /// @inheritdoc ISignedSnapshotStakingPool
-    function approveStaker(bytes calldata _signature) external {
-        _approveStaker(msg.sender, _signature);
+    function approveStaker(bytes calldata signature) external {
+        _approveStaker(msg.sender, signature);
     }
 
     /* ADMIN FUNCTIONS */

--- a/src/staking/SnapshotStakingPool.sol
+++ b/src/staking/SnapshotStakingPool.sol
@@ -262,7 +262,7 @@ contract SnapshotStakingPool is ISnapshotStakingPool, Ownable, ERC20Snapshot, Re
 
     /// @inheritdoc ISnapshotStakingPool
     function getNextSnapshotBufferTime() public view returns (uint256) {
-        return lastSnapshotTime + snapshotDelay - snapshotBuffer;
+        return getNextSnapshotTime() - snapshotBuffer;
     }
 
     /* INTERNAL FUNCTIONS */

--- a/src/staking/SnapshotStakingPool.sol
+++ b/src/staking/SnapshotStakingPool.sol
@@ -12,7 +12,9 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.
 /// @title SnapshotStakingPool
 /// @author Index Cooperative
 /// @notice A contract for staking `stakeToken` and receiving `rewardToken` based 
-/// on snapshots taken when rewards are accrued.
+/// on snapshots taken when rewards are accrued. Snapshots are taken at a minimum
+/// interval of `snapshotDelay` seconds. Staking is not allowed `snapshotBuffer` 
+/// seconds before a snapshot is taken. Rewards are distributed by the `distributor`.
 contract SnapshotStakingPool is ISnapshotStakingPool, Ownable, ERC20Snapshot, ReentrancyGuard {
 
     /* ERRORS */
@@ -73,30 +75,30 @@ contract SnapshotStakingPool is ISnapshotStakingPool, Ownable, ERC20Snapshot, Re
 
     /* CONSTRUCTOR */
 
-    /// @param _name Name of the staked token
-    /// @param _symbol Symbol of the staked token
-    /// @param _rewardToken Instance of the reward token
-    /// @param _stakeToken Instance of the stake token
-    /// @param _distributor Address of the distributor
-    /// @param _snapshotBuffer The buffer time before snapshots during which staking is not allowed
-    /// @param _snapshotDelay The minimum amount of time between snapshots
+    /// @param name Name of the staked token
+    /// @param symbol Symbol of the staked token
+    /// @param rewardToken_ Instance of the reward token
+    /// @param stakeToken_ Instance of the stake token
+    /// @param distributor_ Address of the distributor
+    /// @param snapshotBuffer_ The buffer time before snapshots during which staking is not allowed
+    /// @param snapshotDelay_ The minimum amount of time between snapshots
     constructor(
-        string memory _name,
-        string memory _symbol,
-        IERC20 _rewardToken,
-        IERC20 _stakeToken,
-        address _distributor,
-        uint256 _snapshotBuffer,
-        uint256 _snapshotDelay
+        string memory name,
+        string memory symbol,
+        IERC20 rewardToken_,
+        IERC20 stakeToken_,
+        address distributor_,
+        uint256 snapshotBuffer_,
+        uint256 snapshotDelay_
     )
-        ERC20(_name, _symbol)
+        ERC20(name, symbol)
     {
-        if (_snapshotBuffer > _snapshotDelay) revert InvalidSnapshotBuffer();
-        rewardToken = _rewardToken;
-        stakeToken = _stakeToken;
-        distributor = _distributor;
-        snapshotBuffer = _snapshotBuffer;
-        snapshotDelay = _snapshotDelay;
+        if (snapshotBuffer_ > snapshotDelay_) revert InvalidSnapshotBuffer();
+        rewardToken = rewardToken_;
+        stakeToken = stakeToken_;
+        distributor = distributor_;
+        snapshotBuffer = snapshotBuffer_;
+        snapshotDelay = snapshotDelay_;
         lastSnapshotTime = block.timestamp;
     }
 

--- a/test/staking/HyEthSnapshotStakingPool.t.sol
+++ b/test/staking/HyEthSnapshotStakingPool.t.sol
@@ -33,6 +33,7 @@ contract HyEthSnapshotStakingPoolTest is Test {
     IDebtIssuanceModuleV2 issuanceModule = IDebtIssuanceModuleV2(issuanceModuleAddress);
     IStreamingFeeModule streamingFeeModule = IStreamingFeeModule(streamingFeeModuleAddress);
 
+    uint256 public snapshotBuffer = 1 days;
     uint256 public snapshotDelay = 30 days;
 
     SnapshotStakingPool public snapshotStakingPool;
@@ -55,6 +56,7 @@ contract HyEthSnapshotStakingPoolTest is Test {
             IERC20(hyEthAddress),
             prtHyEth,
             prtFeeSplitExtensionAddress,
+            snapshotBuffer,
             snapshotDelay
         );
 
@@ -87,6 +89,7 @@ contract HyEthSnapshotStakingPoolTest is Test {
         _stake(alice.addr, 1 ether);
         _stake(bob.addr, 1 ether);
 
+        vm.warp(block.timestamp + snapshotDelay + 1);
         prtFeeSplitExtension.accrueFeesAndDistribute();
 
         assert(hyEth.balanceOf(address(snapshotStakingPool)) > 0);

--- a/test/staking/SignedSnapshotStakingPool.t.sol
+++ b/test/staking/SignedSnapshotStakingPool.t.sol
@@ -18,6 +18,7 @@ contract SignedSnapshotStakingPoolTest is Test {
     VmSafe.Wallet carol = vm.createWallet("carol");
     address public distributor = address(0x5);
 
+    uint256 public snapshotBuffer = 1 days;
     uint256 public snapshotDelay = 30 days;
 
     string public eip712Name = "Index Coop";
@@ -39,6 +40,7 @@ contract SignedSnapshotStakingPoolTest is Test {
             IERC20(address(rewardToken)),
             IERC20(address(stakeToken)),
             distributor,
+            snapshotBuffer,
             snapshotDelay
         );
     }
@@ -121,6 +123,20 @@ contract SignedSnapshotStakingPoolTest is Test {
         vm.prank(alice.addr);
         vm.expectRevert(SignedSnapshotStakingPool.InvalidSignature.selector);
         snapshotStakingPool.approveStaker(bobSignature);
+    }
+
+    function testSetMessage() public {
+        string memory newMessage = "I have read and accept the Privacy Policy.";
+
+        vm.expectEmit();
+        emit SignedSnapshotStakingPool.MessageChanged(newMessage);
+        snapshotStakingPool.setMessage(newMessage);
+
+        assertEq(snapshotStakingPool.message(), newMessage);
+
+        vm.prank(bob.addr);
+        vm.expectRevert("Ownable: caller is not the owner");
+        snapshotStakingPool.setMessage(newMessage);
     }
 
     function _signStakeMessage(VmSafe.Wallet memory staker) internal returns (bytes memory) {

--- a/test/staking/SnapshotStakingPool.t.sol
+++ b/test/staking/SnapshotStakingPool.t.sol
@@ -284,13 +284,12 @@ contract SnapshotStakingPoolTest is Test {
     }
 
     function testGetPendingRewards() public {
-        vm.expectRevert(SnapshotStakingPool.InvalidSnapshotId.selector);
-        snapshotStakingPool.getPendingRewards(bob.addr);
+        assertEq(snapshotStakingPool.getPendingRewards(bob.addr), 0);
 
         _stake(bob.addr, 1 ether);
         _stake(alice.addr, 1 ether);
-        vm.expectRevert(SnapshotStakingPool.NonExistentSnapshotId.selector);
-        snapshotStakingPool.getPendingRewards(bob.addr);
+        assertEq(snapshotStakingPool.getPendingRewards(bob.addr), 0);
+        assertEq(snapshotStakingPool.getPendingRewards(alice.addr), 0);
 
         _snapshot(2 ether);
         assertEq(snapshotStakingPool.getPendingRewards(bob.addr), 1 ether);
@@ -298,7 +297,6 @@ contract SnapshotStakingPoolTest is Test {
 
         vm.prank(bob.addr);
         snapshotStakingPool.claim();
-        vm.expectRevert(SnapshotStakingPool.NonExistentSnapshotId.selector);
         assertEq(snapshotStakingPool.getPendingRewards(bob.addr), 0);
 
         _snapshot(1 ether);
@@ -333,11 +331,14 @@ contract SnapshotStakingPoolTest is Test {
     }
 
     function testGetLifetimeRewards() public {
-        vm.expectRevert(SnapshotStakingPool.NonExistentSnapshotId.selector);
-        snapshotStakingPool.getLifetimeRewards(bob.addr);
+        assertEq(snapshotStakingPool.getLifetimeRewards(bob.addr), 0);
 
         _stake(bob.addr, 1 ether);
         _stake(alice.addr, 1 ether);
+
+        assertEq(snapshotStakingPool.getLifetimeRewards(bob.addr), 0);
+        assertEq(snapshotStakingPool.getLifetimeRewards(alice.addr), 0);
+
         _snapshot(2 ether);
 
         assertEq(snapshotStakingPool.getLifetimeRewards(bob.addr), 1 ether);


### PR DESCRIPTION
**Audit Remediations**
+ **[M-01] Allowing anyone to accrue opens significant opportunity to MEV snapshots with a flashloan**
    + Remediation: Add `snapshotBuffer` time where staking is not allowed before snapshot eligibility 
    + https://github.com/IndexCoop/periphery/blob/e4769f70d31d4422e2a8d70f60335e56b38703fd/src/staking/SnapshotStakingPool.sol#L271
    + Note: Intended to still prevent single block MEV when `snapshotDelay` and `snapshotBuffer` are both `0`
+ **[M-02] `lastSnapshotTime` isn't initialized leading to race conditions to get entire first accrue**
    + Remediation: Initialize `lastSnapshotTime` to `block.timestamp` in the constructor
    + https://github.com/IndexCoop/periphery/blob/e4769f70d31d4422e2a8d70f60335e56b38703fd/src/staking/SnapshotStakingPool.sol#L102
+ **[L-01] Stake message visibility and mutability**
    + Change: Add `setMessage()` 
    + https://github.com/IndexCoop/periphery/blob/e4769f70d31d4422e2a8d70f60335e56b38703fd/src/staking/SignedSnapshotStakingPool.sol#L94
+ **[L-02] Reward view function reverts**
    + Change: Return `0` instead of revert in `getPendingRewards()` and `getLifetimeRewards()`
    + https://github.com/IndexCoop/periphery/blob/e4769f70d31d4422e2a8d70f60335e56b38703fd/src/staking/SnapshotStakingPool.sol#L195
    + https://github.com/IndexCoop/periphery/blob/e4769f70d31d4422e2a8d70f60335e56b38703fd/src/staking/SnapshotStakingPool.sol#L228
    + Note: No changes made to `claim()` or `claimPartial()` behavior
+ **[INFO-01] Style fixes** [`e4769f7`](https://github.com/IndexCoop/periphery/pull/4/commits/e4769f70d31d4422e2a8d70f60335e56b38703fd)